### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,39 +25,39 @@ time = "0.1"
 futures = "0.1"
 jsonrpc-core = "8.0"
 jsonrpc-http-server = "8.0"
-lazy_static = "0.2"
-log = "0.3"
-regex = "0.2"
+lazy_static = "1.0"
+log = "0.4"
+regex = "1.0"
 rustc-serialize = "0.3"
-hex = "0.2"
+hex = "0.3"
 serde = "1.0"
 serde_json = "1.0"
 serde_derive = "1.0"
 glob = "0.2"
 uuid = { version = "0.5", features = ["serde", "v4"] }
-secp256k1 = "0.6"
+secp256k1 = { version = "0.9", features = ["rand"] }
 rand = "0.3"
-byteorder="1.0"
+byteorder= "1.2"
 ethabi = "2.0.0"
-num = "0.1.40"
-bitcoin = "0.10.1"
-aes-ctr = "0.1.0"
-sha2 = "0.7.1"
-sha3 = "0.7.3"
-pbkdf2 = "0.2.0"
-scrypt = "0.1.1"
-hmac = "0.6.2"
+num = "0.2"
+bitcoin = "0.13.2"
+aes-ctr = "0.1"
+sha2 = "0.7"
+sha3 = "0.7"
+pbkdf2 = "0.2"
+scrypt = "0.1"
+hmac = "0.6"
 # optional dependencies
 emerald-rocksdb =  { version = "0.10.3", optional = true }
 hyper = { version = "0.11", optional = true }
 reqwest = { version = "0.6", optional = true }
-clippy = {version = "0.0", optional = true}
+clippy = { version = "0.0", optional = true }
 chrono = "0.4"
 hidapi = "0.4"
 
 [dev-dependencies]
 tempdir = "0.3"
-quickcheck = "0.4"
+quickcheck = "0.6"
 # quickcheck_macros = "0.4"
 
 [features]

--- a/src/contract/mod.rs
+++ b/src/contract/mod.rs
@@ -6,7 +6,7 @@ pub use self::error::Error;
 use ethabi::spec::param_type::{ParamType, Reader};
 use ethabi::token::{LenientTokenizer, Token, Tokenizer};
 use ethabi::{Encoder, Function, Interface};
-use hex::ToHex;
+use hex;
 use std::fmt;
 
 /// Contract specification
@@ -60,7 +60,7 @@ impl Contract {
 
         let result = Encoder::encode(tokens);
 
-        Ok(result.to_hex())
+        Ok(hex::encode(result))
     }
 }
 

--- a/src/core/address.rs
+++ b/src/core/address.rs
@@ -2,7 +2,7 @@
 
 use super::util::to_arr;
 use super::Error;
-use hex::{FromHex, ToHex};
+use hex;
 use std::str::FromStr;
 use std::{fmt, ops};
 
@@ -63,13 +63,13 @@ impl FromStr for Address {
             s
         };
 
-        Address::try_from(Vec::from_hex(&value)?.as_slice())
+        Address::try_from(hex::decode(&value)?.as_slice())
     }
 }
 
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "0x{}", self.0.to_hex())
+        write!(f, "0x{}", hex::encode(self.0))
     }
 }
 

--- a/src/core/signature.rs
+++ b/src/core/signature.rs
@@ -3,7 +3,7 @@
 use super::util::{keccak256, to_arr, KECCAK256_BYTES};
 use super::Address;
 use super::Error;
-use hex::{FromHex, ToHex};
+use hex;
 use rand::{OsRng, Rng};
 use secp256k1::key::{PublicKey, SecretKey};
 use secp256k1::{ContextFlag, Message, Secp256k1};
@@ -52,7 +52,7 @@ impl Into<(u8, [u8; 32], [u8; 32])> for Signature {
 
 impl Into<String> for Signature {
     fn into(self) -> String {
-        format!("0x{:X}{}{}", self.v, self.r.to_hex(), self.s.to_hex())
+        format!("0x{:X}{}{}", self.v, hex::encode(self.r), hex::encode(self.s))
     }
 }
 
@@ -96,7 +96,7 @@ impl PrivateKey {
     /// Extract `Address` from current private key.
     pub fn to_address(self) -> Result<Address, Error> {
         let key = PublicKey::from_secret_key(&ECDSA, &self.into())?;
-        let hash = keccak256(&key.serialize_vec(&ECDSA, false)[1..] /* cut '04' */);
+        let hash = keccak256(&key.serialize_uncompressed()[1..] /* cut '04' */);
         Ok(Address(to_arr(&hash[12..])))
     }
 
@@ -166,13 +166,13 @@ impl str::FromStr for PrivateKey {
             s
         };
 
-        PrivateKey::try_from(Vec::from_hex(&value)?.as_slice())
+        PrivateKey::try_from(hex::decode(&value)?.as_slice())
     }
 }
 
 impl fmt::Display for PrivateKey {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "0x{}", self.0.to_hex())
+        write!(f, "0x{}", hex::encode(self.0))
     }
 }
 

--- a/src/core/transaction.rs
+++ b/src/core/transaction.rs
@@ -134,7 +134,7 @@ mod tests {
             "00b413b37c71bfb92719d16e28d7329dea5befa0d0b8190742f89e55617991cf",
         ));
 
-        let hex = tx.to_signed_raw(pk, 61 /*MAINNET_ID*/).unwrap().to_hex();
+        let hex = hex::encode(tx.to_signed_raw(pk, 61 /*MAINNET_ID*/).unwrap());
         assert_eq!(hex,
                     "f86d\
                     808504e3b29200825208\
@@ -187,7 +187,7 @@ mod tests {
             "28b469dc4b039ff63fcd4cb708c668545e644cb25f21df6920aac20e4bc743f7",
         ));
 
-        assert_eq!(tx.to_signed_raw(pk, 62 /*TESTNET_ID*/).unwrap().to_hex(),
+        assert_eq!(hex::encode(tx.to_signed_raw(pk, 62 /*TESTNET_ID*/).unwrap()),
                     "f871\
                     83\
                     100009\

--- a/src/hdwallet/comm.rs
+++ b/src/hdwallet/comm.rs
@@ -112,7 +112,7 @@ pub fn sendrecv(dev: &HidDevice, apdu: &APDU) -> Result<Vec<u8>, Error> {
             set_data(&mut frame[6..], &mut data_itr, CONT_DATA_SIZE);
         }
 
-        if log_enabled!(log::LogLevel::Trace) {
+        if log_enabled!(log::Level::Trace) {
             let parts: Vec<String> = frame.iter().map(|byte| format!("{:02x}", byte)).collect();
             trace!(">> USB send: {}", parts.join(""));
         }

--- a/src/keystore/kdf.rs
+++ b/src/keystore/kdf.rs
@@ -214,7 +214,7 @@ pub mod tests {
             to_32bytes("ae3cd4e7013836a3df6bd7241b12db061dbe2c6785853cce422d148a624ce0bd");
 
         assert_eq!(
-            Kdf::from(8).derive(32, &kdf_salt, "testpassword").to_hex(),
+            hex::encode(Kdf::from(8).derive(32, &kdf_salt, "testpassword")),
             "031dc7e0f4f375f6d6fdab7ad8d71834d844e39a6b62f9fb98d942bab76db0f9"
         );
     }
@@ -225,9 +225,9 @@ pub mod tests {
             to_32bytes("fd4acb81182a2c8fa959d180967b374277f2ccf2f7f401cb08d042cc785464b4");
 
         assert_eq!(
-            Kdf::from((2, 8, 1))
-                .derive(32, &kdf_salt, "1234567890")
-                .to_hex(),
+            hex::encode(
+                Kdf::from((2, 8, 1))
+                        .derive(32, &kdf_salt, "1234567890")),
             "52a5dacfcf80e5111d2c7fbed177113a1b48a882b066a017f2c856086680fac7"
         );
     }

--- a/src/keystore/serialize/byte_array.rs
+++ b/src/keystore/serialize/byte_array.rs
@@ -51,8 +51,8 @@ macro_rules! byte_array_struct {
             where
                 S: ::serde::Serializer,
             {
-                use hex::ToHex;
-                serializer.serialize_str(&self.0.to_hex())
+                use hex;
+                serializer.serialize_str(&hex::encode(&self.0))
             }
         }
 //

--- a/src/keystore/serialize/crypto.rs
+++ b/src/keystore/serialize/crypto.rs
@@ -2,7 +2,7 @@
 
 use super::util::KECCAK256_BYTES;
 use super::{Cipher, CryptoType, Error, KdfParams, KeyFile, Salt, CIPHER_IV_BYTES};
-use hex::{FromHex, ToHex};
+use hex;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::default::Default;
 
@@ -106,7 +106,7 @@ impl From<SerCoreCrypto> for CoreCrypto {
     fn from(ser: SerCoreCrypto) -> Self {
         CoreCrypto {
             cipher: ser.cipher,
-            cipher_text: Vec::from_hex(ser.cipher_text).unwrap(),
+            cipher_text: hex::decode(ser.cipher_text).unwrap(),
             cipher_params: ser.cipher_params,
             kdf_params: ser.kdf_params,
             mac: ser.mac,
@@ -118,7 +118,7 @@ impl Into<SerCoreCrypto> for CoreCrypto {
     fn into(self) -> SerCoreCrypto {
         SerCoreCrypto {
             cipher: self.cipher,
-            cipher_text: self.cipher_text.to_hex(),
+            cipher_text: hex::encode(self.cipher_text),
             cipher_params: self.cipher_params,
             kdf: self.kdf_params.kdf.to_string(),
             kdf_params: self.kdf_params,

--- a/src/rpc/mod.rs
+++ b/src/rpc/mod.rs
@@ -12,7 +12,7 @@ use super::util::{align_bytes, to_arr, to_chain_id, to_even_str, to_u64, trim_he
 use hdwallet::WManager;
 use jsonrpc_core::{Error as JsonRpcError, IoHandler, Params};
 use jsonrpc_http_server::{AccessControlAllowOrigin, DomainsValidation, ServerBuilder};
-use log::LogLevel;
+use log::Level;
 use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::{self, Value};
@@ -229,7 +229,7 @@ pub fn start(
         .start_http(addr)
         .expect("Expect to build HTTP RPC server");
 
-    if log_enabled!(LogLevel::Info) {
+    if log_enabled!(Level::Info) {
         info!("Connector started on http://{}", server.address());
     }
 

--- a/src/util/rlp.rs
+++ b/src/util/rlp.rs
@@ -260,19 +260,19 @@ mod tests {
             .unwrap()
             .as_slice()
             .write_rlp(&mut buf);
-        assert_eq!("8f102030405060708090a0b0c0d0e0f2", buf.to_hex());
+        assert_eq!("8f102030405060708090a0b0c0d0e0f2", hex::encode(buf));
     }
 
     #[test]
     fn encode_mediumint5() {
         let mut buf = Vec::new();
-        Vec::from_hex("0100020003000400050006000700080009000a000b000c000d000e01")
+        hex::decode("0100020003000400050006000700080009000a000b000c000d000e01")
             .unwrap()
             .as_slice()
             .write_rlp(&mut buf);
         assert_eq!(
             "9c0100020003000400050006000700080009000a000b000c000d000e01",
-            buf.to_hex()
+            hex::encode(buf)
         );
     }
 
@@ -296,7 +296,7 @@ mod tests {
         "Lorem ipsum dolor sit amet, consectetur adipisicing eli".write_rlp(&mut buf);
         assert_eq!("b74c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f6e\
                     7365637465747572206164697069736963696e6720656c69",
-                   buf.to_hex());
+                   hex::encode(buf));
     }
 
     #[test]
@@ -305,7 +305,7 @@ mod tests {
         "Lorem ipsum dolor sit amet, consectetur adipisicing elit".write_rlp(&mut buf);
         assert_eq!("b8384c6f72656d20697073756d20646f6c6f722073697420616d65742c20636f\
                     6e7365637465747572206164697069736963696e6720656c6974",
-                   buf.to_hex());
+                   hex::encode(buf));
     }
 
     #[test]
@@ -357,7 +357,7 @@ mod tests {
                     206f726e617265206375727375732c20646f6c6f72206a7573746f20756c7472\
                     69636573206d657475732c20617420756c6c616d636f7270657220766f6c7574\
                     706174",
-                   buf.to_hex());
+                   hex::encode(buf));
     }
 
     #[test]


### PR DESCRIPTION
This PR updates following dependencies:
- log 0.3 -> 0.4
- lazy_static 0.2 -> 1.0
- regex 0.2 -> 1.0
- hex 0.2 -> 0.3
- secp256k1 0.6 -> 0.9
- byteorder 1.0 -> 1.2
- num 0.1 -> 0.2
- bitcoin 0.10 -> 0.13
- quichckeck 0.4 -> 0.6

secp256k1 and bitcoin were also blocking transition from bitcoin to our bip32 fork.